### PR TITLE
Change to load API key via ENV

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -30,7 +30,7 @@ use Mix.Config
 #     import_config "#{Mix.env()}.exs"
 
 config :ex_trails,
-  api_key: "REALAPIKEY"
+  api_key: System.get_env("SCT_API_KEY") || "REALAPIKEY"
 
 if Mix.env() != :test do
   import_config("*.secret.exs")


### PR DESCRIPTION
According to the README.md, it loads the API key via an ENV var.

```
  Or, via an ENV var:
  ```bash
  export SCT_API_KEY="YOUR_API_KEY_HERE"
  ``
```

But the current implementation doesn’t do that. This PR will fix the issue.
